### PR TITLE
Add specificity to header link

### DIFF
--- a/app/partials/header.cjsx
+++ b/app/partials/header.cjsx
@@ -49,7 +49,7 @@ Header = React.createClass
           </div>
           <div className="header__links-inner">
             <UniteLink
-              link="https://github.com/legomushroom/mojs"
+              link="https://github.com/legomushroom/mojs#demos"
               className="header__link"> Demos </UniteLink>
           </div>
           <div className="header__links-inner">


### PR DESCRIPTION
Jump right to the demos section of the README when a user clicks the "demos" link