### PR TITLE
Fix tapping error on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-router": "^0.13.3",
     "react-router-component": "^0.24.4",
     "react-sticky": "^2.1.1",
-    "react-tappable": "^0.5.0-beta.3",
+    "react-tappable": "^0.5.7",
     "tapjs": "^1.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Tried to fix  #15, but hard to try on my local setup. @legomushroom could you try doing an npm install to get the latest version of react-tappable and see if everything works on Android? You can simulate it with Chrome Dev tools using one of the Nexus presets if you don't own one.